### PR TITLE
feat: switch to github arm runners

### DIFF
--- a/.github/workflows/docker-reusable.yml
+++ b/.github/workflows/docker-reusable.yml
@@ -40,7 +40,7 @@ on:
         required: false
         type: string
       arm64_builder:
-        default: buildjet-4vcpu-ubuntu-2204-arm
+        default: ubuntu-22.04-arm
         description: Builder for arm64
         required: false
         type: string


### PR DESCRIPTION
GitHub just announced [Linux arm64 hosted runners now available for free in public repositories (Public Preview)](https://github.blog/changelog/2025-01-16-linux-arm64-hosted-runners-now-available-for-free-in-public-repositories-public-preview/).

And that is a good news
- BuildJet arm sometimes is twice slower than GitHub x86
- They are free for public repositories which fits all our projects

First round of comparison shows the following, for [Docker - Dist-Tests](https://github.com/codex-storage/nim-codex/actions/workflows/docker-dist-tests.yml) builds
| Runner                           | Run 1     | Run 2      | Run 3     |
| -------------------------------- | --------- | ---------- | --------- |
| `ubuntu-22-04`                   | `18m 47s` | `17m 30s ` | `18m 46s` |
| `buildjet-8vcpu-ubuntu-2204-arm` | `47m 25s` | `20m 40s`  | `20m 58s` |
|                                  |           |            |           |
| `ubuntu-22-04`                   | `18m 39s` | `18m 43s`  | `18m 46s` |
| `ubuntu-22-04-arm`               | `18m 36s` | `19m 15s`  | `18m 39s` |

| Runner                           | Architecture | CPU | Memory  |
| -------------------------------- | ------------ | --- | ------- |
| `ubuntu-22-04`                   | `x86_amd64`  | `4` | `16 GB` |
| `buildjet-8vcpu-ubuntu-2204-arm` | `arm64`      | `8` | `12 GB` |
| `ubuntu-22-04-arm`               | `arm64`      | `4` | `16 GB` |
 - [Standard GitHub-hosted runners for public repositories](https://docs.github.com/en/actions/using-github-hosted-runners/using-github-hosted-runners/about-github-hosted-runners#standard-github-hosted-runners-for-public-repositories)
 - [BuildJet / Hardware / ARM](https://buildjet.com/for-github-actions/docs/runners/hardware#arm)

However, 2 of 5 runs were failed on arm and we need to investigate it. On BuildJet we solved it by using a runner with higher memory.

Because our other projects are not memory consuming, we can switch current reusable workflow to GitHub arm runner and start to update projects to use it.