### PR TITLE
chore: update create-matrix-action version

### DIFF
--- a/.github/workflows/docker-reusable.yml
+++ b/.github/workflows/docker-reusable.yml
@@ -66,7 +66,7 @@ jobs:
     steps:
       - name: Compute matrix
         id: matrix
-        uses: fabiocaccamo/create-matrix-action@v4
+        uses: fabiocaccamo/create-matrix-action@v5
         with:
           matrix: |
             os {linux}, arch {amd64}, builder {$${{ env.amd64_builder }}}


### PR DESCRIPTION
PR updates `fabiocaccamo/create-matrix-action` to the latest release.