### PR TITLE
docker-reusable: add actions/checkout options

### DIFF
--- a/.github/workflows/docker-reusable.yml
+++ b/.github/workflows/docker-reusable.yml
@@ -34,6 +34,16 @@ on:
         description: Suffix for Docker images tag
         required: false
         type: string
+      checkout-fetch-depth:
+        default: ''
+        description: actions/checkout fetch-depth
+        required: false
+        type: string
+      checkout-fetch-tags:
+        default: ''
+        description: actions/checkout fetch-tags
+        required: false
+        type: string
       amd64_builder:
         default: ubuntu-22.04
         description: Builder for amd64
@@ -53,6 +63,8 @@ env:
   TAG_LATEST: ${{ inputs.tag_latest }}
   TAG_SHA: ${{ inputs.tag_sha }}
   TAG_SUFFIX: ${{ inputs.tag_suffix }}
+  CHECKOUT_FETCH_DEPTH: ${{ inputs.checkout-fetch-depth }}
+  CHECKOUT_FETCH_TAGS: ${{ inputs.checkout-fetch-tags }}
   amd64_builder: ${{ inputs.amd64_builder }}
   arm64_builder: ${{ inputs.arm64_builder }}
 
@@ -87,6 +99,9 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: ${{ env.CHECKOUT_FETCH_DEPTH }}
+          fetch-tags: ${{ env.CHECKOUT_FETCH_TAGS }}
 
       - name: Secrets to variables
         if: ${{ env.BUILD_ARGS != '' }}

--- a/README.md
+++ b/README.md
@@ -19,16 +19,18 @@
 
 #### Inputs
 
-| Variable         | Description                        |
-| ---------------- | ---------------------------------- |
-| `docker_file`    | Path to Dockerfile                 |
-| `dockerhub_repo` | DockerHub repository               |
-| `build_args`     | Build arguments                    |
-| `tag_latest`     | Set latest tag for Docker images   |
-| `tag_sha`        | Set Git short commit as Docker tag |
-| `tag_suffix`     | Suffix for Docker images tag       |
-| `amd64_builder`  | Builder for amd64                  |
-| `arm64_builder`  | Builder for arm64                  |
+| Variable               | Description                        | Default             |
+| ---------------------- | ---------------------------------- | ------------------- |
+| `docker_file`          | Path to Dockerfile                 | `docker/Dockerfile` |
+| `dockerhub_repo`       | DockerHub repository               | `codexstorage/test` |
+| `build_args`           | Build arguments                    | `''`                |
+| `tag_latest`           | Set latest tag for Docker images   | `true`              |
+| `tag_sha`              | Set Git short commit as Docker tag | `true`              |
+| `tag_suffix`           | Suffix for Docker images tag       | `''`                |
+| `checkout-fetch-depth` | actions/checkout fetch-depth       | `''`                |
+| `checkout-fetch-tags`  | actions/checkout fetch-tags        | `''`                |
+| `amd64_builder`        | Builder for amd64                  | `ubuntu-22.04`      |
+| `arm64_builder`        | Builder for arm64                  | `ubuntu-22.04-arm`  |
 
 
 #### Secrets
@@ -78,10 +80,14 @@ jobs:
     with:
       docker_file: docker/Dockerfile
       dockerhub_repo: codexstorage/test
-      tag_latest: ${{ github.ref_name == github.event.repository.default_branch || startsWith(github.ref, 'refs/tags/') }}
-      amd64_builder: ubuntu-24.04
       build_args: |
         VITE_CODEX_API_URL=${VITE_CODEX_API_URL}
         VITE_GEO_IP_URL="Plain text"
+      tag_latest: ${{ github.ref_name == github.event.repository.default_branch || startsWith(github.ref, 'refs/tags/') }}
+      tag_suffix: 'custom'
+      checkout-fetch-depth: 0
+      checkout-fetch-tags: true
+      amd64_builder: ubuntu-24.04
+      arm64_builder: ubuntu-24.04-arm
     secrets: inherit
 ```


### PR DESCRIPTION
During the try to apply [Docker - Reusable](https://github.com/codex-storage/github-actions#docker---reusable) workflow to the the [codex-storage/deluge](https://github.com/codex-storage/deluge) it was discovered that we need to use specific options for [actions/checkout](https://github.com/actions/checkout).

- Two options were added to the reusable workflow
- Documentation was updated as well