### PR TITLE
`docker_context` support

### DIFF
--- a/.github/workflows/docker-reusable.yml
+++ b/.github/workflows/docker-reusable.yml
@@ -9,6 +9,11 @@ on:
         description: Dockerfile
         required: true
         type: string
+      docker_context:
+        default: .
+        description: Docker build context
+        required: true
+        type: string
       dockerhub_repo:
         default: codexstorage/test
         description: DockerHub repository
@@ -58,6 +63,7 @@ on:
 
 env:
   DOCKER_FILE: ${{ inputs.docker_file }}
+  DOCKER_CONTEXT: ${{ inputs.docker_context }}
   DOCKERHUB_REPO: ${{ inputs.dockerhub_repo }}
   BUILD_ARGS: ${{ inputs.build_args }}
   TAG_LATEST: ${{ inputs.tag_latest }}
@@ -138,7 +144,7 @@ jobs:
         id: build
         uses: docker/build-push-action@v6
         with:
-          context: .
+          context: ${{ env.DOCKER_FILE }}
           file: ${{ env.DOCKER_FILE }}
           platforms: ${{ env.PLATFORM }}
           push: true

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@
 | Variable               | Description                        | Default             |
 | ---------------------- | ---------------------------------- | ------------------- |
 | `docker_file`          | Path to Dockerfile                 | `docker/Dockerfile` |
+| `docker_context`       | Docker build context               | `.` |
 | `dockerhub_repo`       | DockerHub repository               | `codexstorage/test` |
 | `build_args`           | Build arguments                    | `''`                |
 | `tag_latest`           | Set latest tag for Docker images   | `true`              |


### PR DESCRIPTION
This adds support to specify context for Docker build. This enables to build Docker image in subdirectory of the Git repo.