### PR TITLE
fix: rename docker_context to docker_build_context

### DIFF
--- a/.github/workflows/docker-reusable.yml
+++ b/.github/workflows/docker-reusable.yml
@@ -9,7 +9,7 @@ on:
         description: Dockerfile
         required: true
         type: string
-      docker_context:
+      docker_build_context:
         default: .
         description: Docker build context
         required: false
@@ -63,7 +63,7 @@ on:
 
 env:
   DOCKER_FILE: ${{ inputs.docker_file }}
-  DOCKER_CONTEXT: ${{ inputs.docker_context }}
+  DOCKER_BUILD_CONTEXT: ${{ inputs.docker_build_context }}
   DOCKERHUB_REPO: ${{ inputs.dockerhub_repo }}
   BUILD_ARGS: ${{ inputs.build_args }}
   TAG_LATEST: ${{ inputs.tag_latest }}
@@ -144,7 +144,7 @@ jobs:
         id: build
         uses: docker/build-push-action@v6
         with:
-          context: ${{ env.DOCKER_CONTEXT }}
+          context: ${{ env.DOCKER_BUILD_CONTEXT }}
           file: ${{ env.DOCKER_FILE }}
           platforms: ${{ env.PLATFORM }}
           push: true

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
 | Variable               | Description                        | Default             |
 | ---------------------- | ---------------------------------- | ------------------- |
 | `docker_file`          | Path to Dockerfile                 | `docker/Dockerfile` |
-| `docker_context`       | Docker build context               | `.` |
+| `docker_build_context` | Docker build context               | `.`                 |
 | `dockerhub_repo`       | DockerHub repository               | `codexstorage/test` |
 | `build_args`           | Build arguments                    | `''`                |
 | `tag_latest`           | Set latest tag for Docker images   | `true`              |


### PR DESCRIPTION
@AuHau, we hit another issue 😄 

GitHub Action [build-push-action](https://github.com/docker/build-push-action) has two inputs
 - `build-contexts` - List of additional [build contexts](https://docs.docker.com/engine/reference/commandline/buildx_build/#build-context) (e.g., name=path)
 - `context` - Build's context is the set of files located in the specified [PATH or URL](https://docs.docker.com/engine/reference/commandline/build/) (default [Git context](https://github.com/docker/build-push-action#git-context))

We just extended our workflow to use a `context` in terms of [Build context](https://docs.docker.com/build/concepts/context/). At the same time Docker has [Docker contexts](https://docs.docker.com/engine/manage-resources/contexts/), which is referring to a mechanism to manage multiple Docker daemons from a single client.

During implementation we added a global variable `DOCKER_CONTEXT` which is a Docker internal variable responsible for the "connection context" and not a "build context". That variables clash make other docker commands to fail.

That story starts from the variables clash and from other hand because we are using intermediate global variables in a workflow. I've added them just to have a better overview what is happening in a workflow and to have an easy way to manage them all.

So, we have two options to fix that
 - Do not use an intermediate `DOCKER_CONTEXT: ${{ inputs.docker_context }}` and refer in the step using just an input
 - Rename variable and input to the `DOCKER_BUILD_CONTEXT: ${{ inputs.docker_build_context }}`

I would propose to still use an intermediate global variable and just rename it. In that case, we should keep in mind a mentioned above `build-contexts` input, which when/if used will result in the something like `DOCKER_BUILD_CONTEXTS`, which will add some additional confusions in all we have here 😄 
```yaml
DOCKER_BUILD_CONTEXT: ${{ inputs.docker_build_context }}   # context - renamed
DOCKER_BUILD_CONTEXTS: ${{ inputs.docker_build_contexts }} # build-contexts - not used yet
```

<img width="1480" alt="Screenshot 2025-04-03 at 06 54 03" src="https://github.com/user-attachments/assets/f083be7f-51ee-4721-aeb9-3acfbdd74485" />
