### PR TITLE
fix: make docker reusable workflow more reusable

### DIFF
--- a/.github/workflows/docker-reusable.yml
+++ b/.github/workflows/docker-reusable.yml
@@ -93,7 +93,12 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       matrix: ${{ steps.matrix.outputs.matrix }}
+      build_id: ${{ steps.build_id.outputs.build_id }}
     steps:
+      - name: Generate unique build id
+        id: build_id
+        run: echo "build_id=$(openssl rand -hex 5)" >> $GITHUB_OUTPUT
+
       - name: Compute matrix
         id: matrix
         uses: fabiocaccamo/create-matrix-action@v5
@@ -104,16 +109,16 @@ jobs:
 
   # Build platform specific image
   build:
+    name: Build ${{ matrix.os }}/${{ matrix.arch }}
+    runs-on: ${{ matrix.builder }}
     needs: compute
     strategy:
       fail-fast: true
       matrix:
         include: ${{ fromJson(needs.compute.outputs.matrix) }}
-
-    name: Build ${{ matrix.os }}/${{ matrix.arch }}
-    runs-on: ${{ matrix.builder }}
     env:
       PLATFORM: ${{ format('{0}/{1}', 'linux', matrix.arch) }}
+
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -175,7 +180,7 @@ jobs:
       - name: Docker - Upload digest
         uses: actions/upload-artifact@v4
         with:
-          name: digests-${{ matrix.arch }}
+          name: digests-${{ needs.compute.outputs.build_id }}-${{ matrix.arch }}
           path: /tmp/digests/*
           if-no-files-found: error
           retention-days: 1
@@ -185,7 +190,7 @@ jobs:
   publish:
     name: Publish multi-platform image
     runs-on: ubuntu-latest
-    needs: build
+    needs: [build, compute]
     steps:
       - name: Docker - Variables
         run: |
@@ -214,7 +219,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           path: /tmp/digests
-          pattern: digests-*
+          pattern: digests-${{ needs.compute.outputs.build_id }}-*
           merge-multiple: true
 
       - name: Docker - Set up Buildx


### PR DESCRIPTION
This is a quick fix for a docker-reusable workflow discovered by @AuHau, to make it more reusable.

Before, we used a very simple artifacts names in form of `digests-${{ matrix.arch }}` which leads to
```
digests-amd64
digests-arm64
```

At the same time, if we reuse a workflow twice, it will generate same names and will fail to upload them as they already exists.

To solve that, we generate an uniquie `build_id` for each set of builds. We do not use `run_id`, to not confuse it with a [`github.run_id`](https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/accessing-contextual-information-about-workflow-runs#github-context).

Basically, the issue is started because we are using this repository [`docker-reusable.yml`](https://github.com/codex-storage/github-actions/blob/master/.github/workflows/docker-reusable.yml) workflow in a combination with a [`codex-storage/nim-codex/docker-reusable.yml`](https://github.com/codex-storage/nim-codex/blob/master/.github/workflows/docker-reusable.yml) workflow, and they both are using same approach. So, the second one needs to be updated as well.

Some cosmetic fields reordering was done to have more clear visibility.

An example of the unique artifacts
<img width="1138" alt="Screenshot 2025-04-04 at 14 50 40" src="https://github.com/user-attachments/assets/48a9b89f-a2b8-429b-8f8e-5c90f0d29087" />